### PR TITLE
remove unnecessary webservers from prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx
 COPY default.conf /etc/nginx/conf.d/default.conf
 COPY build /usr/share/nginx/html
-EXPOSE 4001
+EXPOSE 80 443

--- a/build-site.sh
+++ b/build-site.sh
@@ -1,0 +1,2 @@
+docker build -t uwiuga/site .
+docker push uwiuga/site

--- a/default.conf
+++ b/default.conf
@@ -1,45 +1,17 @@
 server {
-    listen       4001;
-    server_name  localhost;
+    listen       80;
+    listen       [::]:80;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    return 301 https://iuga.info$request_uri;
+}
 
-    #charset koi8-r;
-    #access_log  /var/log/nginx/log/host.access.log  main;
+server {
+    listen       443 ssl;
+    ssl_certificate /certs/iuga/fullchain.pem;
+    ssl_certificate_key /certs/iuga/iuga.info-key.pem;
 
     location / {
         root   /usr/share/nginx/html;
         try_files $uri /index.html /index.htm;
     }
-
-    #error_page  404              /404.html;
-
-    # redirect server error pages to the static page /50x.html
-    #
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
-    }
-
-    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
-    #
-    #location ~ \.php$ {
-    #    proxy_pass   http://127.0.0.1;
-    #}
-
-    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-    #
-    #location ~ \.php$ {
-    #    root           html;
-    #    fastcgi_pass   127.0.0.1:9000;
-    #    fastcgi_index  index.php;
-    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
-    #    include        fastcgi_params;
-    #}
-
-    # deny access to .htaccess files, if Apache's document root
-    # concurs with nginx's one
-    #
-    #location ~ /\.ht {
-    #    deny  all;
-    #}
 }
-

--- a/deploy-events.sh
+++ b/deploy-events.sh
@@ -1,3 +1,5 @@
+# THIS SCRIPT IS DEPRECATED
+
 docker pull brendankellogg/iugaevtapi
 docker pull redis
 

--- a/deploy-gateway.sh
+++ b/deploy-gateway.sh
@@ -1,3 +1,5 @@
+# THIS SCRIPT IS DEPRECATED
+
 docker rm -f iugaserver
 
 docker run -d --name iugaserver \

--- a/deploy-site.sh
+++ b/deploy-site.sh
@@ -1,3 +1,5 @@
+# THIS SCRIPT IS DEPRECATED
+
 docker pull brendankellogg/iuga-site
 
 docker rm -f iuga-site


### PR DESCRIPTION
Since the event API is no longer used, remove both that and the gateway server and simply set the site's nginx to serve HTTPS.